### PR TITLE
Use aiohttp>=3.8.5 instead of double mention

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-aiohttp==3.8.5
-aiohttp==3.8.6
+aiohttp>=3.8.5
 aiolimiter==1.1.0
 autoacu==0.1.0
 datasets==2.14.5


### PR DESCRIPTION
`aiohttp` is mentioned twice in the requirements.txt file with versions `3.8.5` and `3.8.6`.  This results in a resolving error while running `pip install`. Using `>=3.8.5` so that pip picks the most suitable version automatically